### PR TITLE
Fix browser compatibility for GitHub Pages static version by creating consolidated rules bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Compatible with tables from Confluence, Google Docs, Word, and other rich text sources
 - Added 9 comprehensive unit tests for table conversion functionality
 
+### Fixed
+- **Static version (GitHub Pages)** - Fixed browser compatibility issues
+  - Created browser-compatible consolidated rules bundle (`docs/turndownRules.js`)
+  - Fixed script loading path from `../lib/turndownRules.js` to `turndownRules.js`
+  - Included all conversion rules (code blocks, inline code, tasks, lists, and tables) in browser bundle
+  - Removed Node.js-specific `require()` statements for browser compatibility
+
 ## [1.1.1] - 2026-02-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ Confluence code block → ```javascript
 - **Express** - Web server framework
 - **Turndown** - HTML to Markdown converter (successor to to-markdown)
 
+## Development
+
+### Building the Browser Bundle
+
+The browser version (`docs/`) uses a bundled version of the conversion rules. When you modify rules in `lib/rules/`, regenerate the browser bundle:
+
+```bash
+npm run build:browser
+```
+
+This script (`build-browser.js`) automatically:
+- Reads all rule files from `lib/rules/`
+- Removes Node.js-specific code (`require`, `module.exports`)
+- Bundles them into a single browser-compatible file at `docs/turndownRules.js`
+
+**Important:** Always run `npm run build:browser` after modifying any rule files to keep the browser version in sync.
+
 ## Deployment
 
 ### GitHub Pages (Client-Side Version)

--- a/build-browser.js
+++ b/build-browser.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const rulesDir = path.join(__dirname, 'lib', 'rules');
+const outputFile = path.join(__dirname, 'docs', 'turndownRules.js');
+
+const allFiles = fs.readdirSync(rulesDir);
+const ruleFiles = allFiles.filter(file => 
+  file.endsWith('.js') && file !== 'index.js' && file !== 'README.md'
+).sort();
+
+console.log(`Found ${ruleFiles.length} rule files:`, ruleFiles);
+
+let bundleContent = '// Browser-compatible Turndown rules bundle\n';
+bundleContent += '// Auto-generated from lib/rules/ - DO NOT EDIT MANUALLY\n';
+bundleContent += '// Run: node build-browser.js to regenerate\n\n';
+
+const ruleFunctionNames = [];
+
+ruleFiles.forEach(file => {
+  const filePath = path.join(rulesDir, file);
+  let content = fs.readFileSync(filePath, 'utf8');
+  
+  const functionMatch = content.match(/function\s+(\w+)\s*\(/);
+  if (functionMatch) {
+    ruleFunctionNames.push(functionMatch[1]);
+  }
+  
+  content = content.replace(/\/\/ Export for Node\.js[\s\S]*$/m, '');
+  
+  bundleContent += content.trim() + '\n\n';
+});
+
+const turndownRulesPath = path.join(__dirname, 'lib', 'turndownRules.js');
+let turndownRulesContent = fs.readFileSync(turndownRulesPath, 'utf8');
+
+const getTurndownOptionsMatch = turndownRulesContent.match(/function getTurndownOptions\(\)[\s\S]*?\n}/);
+if (getTurndownOptionsMatch) {
+  bundleContent += getTurndownOptionsMatch[0] + '\n\n';
+}
+
+const ruleCalls = ruleFunctionNames.map(name => `  ${name}(turndownService);`).join('\n');
+
+bundleContent += `// Main function to add all rules
+function addConfluenceRules(turndownService) {
+${ruleCalls}
+}
+`;
+
+fs.writeFileSync(outputFile, bundleContent);
+
+console.log('✓ Browser bundle generated successfully at docs/turndownRules.js');

--- a/docs/index.html
+++ b/docs/index.html
@@ -49,7 +49,7 @@
   </div>
 
   <script src="https://unpkg.com/turndown@7.1.2/dist/turndown.js"></script>
-  <script src="../lib/turndownRules.js"></script>
+  <script src="turndownRules.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/docs/turndownRules.js
+++ b/docs/turndownRules.js
@@ -1,0 +1,374 @@
+// Browser-compatible Turndown rules bundle
+// Auto-generated from lib/rules/ - DO NOT EDIT MANUALLY
+// Run: node build-browser.js to regenerate
+
+// Rule for converting Confluence code blocks to Markdown fenced code blocks
+// Handles various Confluence HTML structures including modern SPAN-based blocks
+
+function confluenceCodeBlock(turndownService) {
+  turndownService.addRule('confluenceCodeBlock', {
+    filter: function (node) {
+      if (node.nodeName !== 'DIV' && node.nodeName !== 'PRE' && node.nodeName !== 'SPAN') return false;
+      
+      const className = node.className || '';
+      const dataLanguage = node.getAttribute('data-language');
+      const dataCodeLang = node.getAttribute('data-code-lang');
+      const dataCodeBlock = node.getAttribute('data-ds--code--code-block');
+      
+      // Check for SPAN with data-code-lang (modern Confluence)
+      if (node.nodeName === 'SPAN' && (dataCodeLang || dataCodeBlock !== null)) {
+        return true;
+      }
+      
+      // Check for various Confluence code block patterns
+      if (
+        className.includes('code-block') ||
+        className.includes('codeBlock') ||
+        className.includes('ak-renderer-code-block') ||
+        className.includes('codeContent') ||
+        className.includes('syntaxhighlighter') ||
+        dataLanguage ||
+        dataCodeLang
+      ) {
+        return true;
+      }
+      
+      // Check if it's a pre element with code-related attributes
+      if (node.nodeName === 'PRE' && (
+        className.includes('code') ||
+        node.parentNode.className.includes('code')
+      )) {
+        return true;
+      }
+      
+      // Check for div containing pre with code
+      if (node.nodeName === 'DIV' && node.querySelector('pre')) {
+        const parent = node;
+        const hasCodeIndicator = 
+          className.includes('code') ||
+          parent.querySelector('[class*="code"]') ||
+          parent.querySelector('[class*="syntaxhighlighter"]') ||
+          parent.querySelector('pre > code');
+        
+        if (hasCodeIndicator) {
+          return true;
+        }
+      }
+      
+      return false;
+    },
+    replacement: function (content, node) {
+      let language = '';
+      let codeContent = '';
+      
+      // Try to detect language from data-code-lang attribute
+      // Check the node itself first, then child elements
+      const dataCodeLang = node.getAttribute('data-code-lang');
+      if (dataCodeLang) {
+        language = dataCodeLang;
+      } else {
+        // Look for data-code-lang in child elements (modern Confluence)
+        const spanWithLang = node.querySelector('[data-code-lang]');
+        if (spanWithLang) {
+          language = spanWithLang.getAttribute('data-code-lang') || '';
+        }
+      }
+      
+      // Fallback: try other attributes if language not found
+      if (!language) {
+        const dataLanguage = node.getAttribute('data-language');
+        const langClass = node.className.match(/language-(\w+)/);
+        const brushClass = node.className.match(/brush:\s*(\w+)/);
+        
+        if (dataLanguage) {
+          language = dataLanguage;
+        } else if (langClass && langClass[1]) {
+          language = langClass[1];
+        } else if (brushClass && brushClass[1]) {
+          language = brushClass[1];
+        }
+      }
+      
+      // Extract code content
+      const preElement = node.querySelector('pre');
+      const codeElement = node.querySelector('code');
+      
+      // Check if code is structured with line elements (modern Confluence)
+      const lineElements = node.querySelectorAll('[data-testid^="renderer-code-block-line-"]');
+      
+      if (lineElements && lineElements.length > 0) {
+        // Extract text from each line element, preserving whitespace
+        const lines = Array.from(lineElements).map(line => {
+          // Confluence stores code with proper whitespace in nested span elements
+          // The HTML parser collapses whitespace-only text nodes, so we need to
+          // extract from innerHTML and strip HTML tags while preserving spaces
+          
+          // Get innerHTML and strip HTML tags to get raw text with whitespace
+          const innerHTML = line.innerHTML || '';
+          
+          // Simple HTML tag removal that preserves text content including whitespace
+          // This is more reliable than textContent which collapses whitespace
+          let text = innerHTML
+            .replace(/<br\s*\/?>/gi, '\n')  // Convert <br> to newlines
+            .replace(/<[^>]+>/g, '');        // Remove all HTML tags
+          
+          // Decode HTML entities
+          text = text
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&')
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, "'");
+          
+          return text;
+        });
+        codeContent = lines.join('\n');
+      } else if (codeElement) {
+        codeContent = codeElement.textContent || '';
+      } else if (preElement) {
+        codeContent = preElement.textContent || '';
+      } else if (node.nodeName === 'PRE') {
+        codeContent = node.textContent || '';
+      } else {
+        codeContent = node.textContent || '';
+      }
+      
+      // Clean up line numbers if present (common in Confluence)
+      // Line numbers are typically at the start of each line followed by whitespace
+      // But we need to preserve the actual code indentation
+      const lines = codeContent.split('\n');
+      const cleanedLines = lines.map(line => {
+        // Remove line numbers at the start (e.g., "1  " or "12  ")
+        // but preserve any indentation that comes after the line number
+        // Pattern: optional whitespace, digits, two or more spaces
+        // We only remove if there are 2+ spaces after the number (line number separator)
+        return line.replace(/^\d+\s{2,}/, '');
+      });
+      
+      // Join lines but DON'T trim - that would remove indentation!
+      // Only remove trailing newlines at the very end
+      codeContent = cleanedLines.join('\n').replace(/\n+$/, '');
+      
+      return '\n```' + language + '\n' + codeContent + '\n```\n\n';
+    }
+  });
+}
+
+// Rule for converting Confluence inline code spans to Markdown inline code
+
+function confluenceCodeSpan(turndownService) {
+  turndownService.addRule('confluenceCodeSpan', {
+    filter: function (node) {
+      if (node.nodeName !== 'SPAN' && node.nodeName !== 'CODE') return false;
+      
+      const className = node.className || '';
+      return (
+        className.includes('code') ||
+        className.includes('monospace') ||
+        node.getAttribute('data-inline-code') === 'true'
+      );
+    },
+    replacement: function (content, node) {
+      const text = node.textContent || '';
+      return '`' + text + '`';
+    }
+  });
+}
+
+function confluenceListItem(turndownService) {
+  turndownService.addRule('confluenceListItem', {
+    filter: function (node) {
+      return (
+        node.nodeName === 'LI' &&
+        node.querySelector('p[data-renderer-start-pos]') &&
+        !node.querySelector('input[type="checkbox"]')
+      );
+    },
+    replacement: function (content, node, options) {
+      content = content.replace(/^\n+|\n+$/g, '').trim();
+      
+      const prefix = options.bulletListMarker || '-';
+      let indent = '';
+      
+      let parent = node.parentNode;
+      let depth = 0;
+      while (parent) {
+        if (parent.nodeName === 'UL' || parent.nodeName === 'OL') {
+          depth++;
+        }
+        parent = parent.parentNode;
+      }
+      
+      if (depth > 1) {
+        indent = '    '.repeat(depth - 1);
+      }
+      
+      return indent + prefix + '   ' + content + '\n';
+    }
+  });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = confluenceListItem;
+}
+
+// Rule for handling Confluence task container elements
+
+function confluenceTaskContainer(turndownService) {
+  turndownService.addRule('confluenceTaskContainer', {
+    filter: function (node) {
+      return (
+        node.nodeName === 'DIV' &&
+        (node.getAttribute('data-task-local-id') || 
+         node.getAttribute('role') === 'group')
+      );
+    },
+    replacement: function (content) {
+      return content;
+    }
+  });
+}
+
+// Rule for converting Confluence task lists with checkboxes to Markdown task lists
+
+function confluenceTaskWrapper(turndownService) {
+  turndownService.addRule('confluenceTaskWrapper', {
+    filter: function (node) {
+      return (
+        node.nodeName === 'DIV' &&
+        node.querySelector('input[type="checkbox"]') &&
+        node.querySelector('[data-component="content"]')
+      );
+    },
+    replacement: function (content, node) {
+      const checkbox = node.querySelector('input[type="checkbox"]');
+      const contentDiv = node.querySelector('[data-component="content"]');
+      
+      if (!checkbox || !contentDiv) {
+        return content;
+      }
+      
+      let depth = 0;
+      let parent = node.parentNode;
+      while (parent) {
+        if (parent.nodeName === 'DIV' && parent.getAttribute('role') === 'group') {
+          const style = parent.getAttribute('style') || '';
+          if (style.includes('margin') && style.includes('24px')) {
+            depth++;
+          }
+        }
+        parent = parent.parentNode;
+      }
+      
+      const indent = '  '.repeat(depth);
+      const checked = checkbox.checked || checkbox.hasAttribute('checked');
+      const prefix = checked ? '- [x] ' : '- [ ] ';
+      const text = contentDiv.textContent.trim();
+      
+      return indent + prefix + text + '\n';
+    }
+  });
+}
+
+function table(turndownService) {
+  turndownService.addRule('table', {
+    filter: 'table',
+    replacement: function (content, node) {
+      const rows = Array.from(node.querySelectorAll('tr'));
+      if (rows.length === 0) return '';
+
+      const tableData = [];
+      let hasHeader = false;
+      let columnCount = 0;
+
+      rows.forEach((row, rowIndex) => {
+        const cells = Array.from(row.querySelectorAll('th, td'));
+        const rowData = cells.map(cell => {
+          const cellContent = cell.textContent || '';
+          return cellContent.trim().replace(/\n/g, ' ').replace(/\|/g, '\\|');
+        });
+
+        if (rowIndex === 0 && row.querySelector('th')) {
+          hasHeader = true;
+        }
+
+        tableData.push(rowData);
+        columnCount = Math.max(columnCount, rowData.length);
+      });
+
+      if (tableData.length === 0) return '';
+
+      const normalizedData = tableData.map(row => {
+        while (row.length < columnCount) {
+          row.push('');
+        }
+        return row;
+      });
+
+      const columnWidths = [];
+      for (let i = 0; i < columnCount; i++) {
+        let maxWidth = 3;
+        normalizedData.forEach(row => {
+          if (row[i]) {
+            maxWidth = Math.max(maxWidth, row[i].length);
+          }
+        });
+        columnWidths.push(maxWidth);
+      }
+
+      const formatRow = (rowData) => {
+        return '| ' + rowData.map((cell, i) => {
+          return cell.padEnd(columnWidths[i], ' ');
+        }).join(' | ') + ' |';
+      };
+
+      const lines = [];
+      
+      if (hasHeader && normalizedData.length > 0) {
+        lines.push(formatRow(normalizedData[0]));
+        
+        const separatorRow = columnWidths.map(width => '-'.repeat(width));
+        lines.push('| ' + separatorRow.join(' | ') + ' |');
+        
+        for (let i = 1; i < normalizedData.length; i++) {
+          lines.push(formatRow(normalizedData[i]));
+        }
+      } else {
+        normalizedData.forEach(row => {
+          lines.push(formatRow(row));
+        });
+      }
+
+      return '\n' + lines.join('\n') + '\n\n';
+    }
+  });
+
+  turndownService.addRule('tableCell', {
+    filter: ['th', 'td'],
+    replacement: function (content) {
+      return content;
+    }
+  });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = table;
+}
+
+function getTurndownOptions() {
+  return {
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-'
+  };
+}
+
+// Main function to add all rules
+function addConfluenceRules(turndownService) {
+  confluenceCodeBlock(turndownService);
+  confluenceCodeSpan(turndownService);
+  confluenceListItem(turndownService);
+  confluenceTaskContainer(turndownService);
+  confluenceTaskWrapper(turndownService);
+  table(turndownService);
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node --watch server.js",
-    "test": "node --test"
+    "test": "node --test",
+    "build:browser": "node build-browser.js"
   },
   "keywords": ["clipboard", "markdown", "converter"],
   "author": "",

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -1,0 +1,97 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+test('browser bundle is up-to-date with source rules', () => {
+  const docsBundle = path.join(__dirname, '..', 'docs', 'turndownRules.js');
+  
+  assert.ok(fs.existsSync(docsBundle), 'Browser bundle should exist at docs/turndownRules.js');
+  
+  const currentBundle = fs.readFileSync(docsBundle, 'utf8');
+  
+  const tempBundle = path.join(__dirname, '..', 'docs', 'turndownRules.js.tmp');
+  const originalBundle = path.join(__dirname, '..', 'docs', 'turndownRules.js.bak');
+  
+  try {
+    fs.renameSync(docsBundle, originalBundle);
+    
+    execSync('node build-browser.js', { 
+      cwd: path.join(__dirname, '..'),
+      stdio: 'pipe'
+    });
+    
+    const freshBundle = fs.readFileSync(docsBundle, 'utf8');
+    
+    fs.renameSync(docsBundle, tempBundle);
+    fs.renameSync(originalBundle, docsBundle);
+    
+    const currentNormalized = currentBundle.replace(/\r\n/g, '\n').trim();
+    const freshNormalized = freshBundle.replace(/\r\n/g, '\n').trim();
+    
+    assert.strictEqual(
+      currentNormalized,
+      freshNormalized,
+      'Browser bundle is out of date. Run "npm run build:browser" to regenerate it.'
+    );
+    
+    fs.unlinkSync(tempBundle);
+  } catch (error) {
+    if (fs.existsSync(originalBundle)) {
+      fs.renameSync(originalBundle, docsBundle);
+    }
+    if (fs.existsSync(tempBundle)) {
+      fs.unlinkSync(tempBundle);
+    }
+    throw error;
+  }
+});
+
+test('browser bundle contains all rule functions', () => {
+  const docsBundle = path.join(__dirname, '..', 'docs', 'turndownRules.js');
+  const bundleContent = fs.readFileSync(docsBundle, 'utf8');
+  
+  const rulesDir = path.join(__dirname, '..', 'lib', 'rules');
+  const ruleFiles = fs.readdirSync(rulesDir).filter(file => 
+    file.endsWith('.js') && file !== 'index.js'
+  );
+  
+  ruleFiles.forEach(file => {
+    const filePath = path.join(rulesDir, file);
+    const content = fs.readFileSync(filePath, 'utf8');
+    const functionMatch = content.match(/function\s+(\w+)\s*\(/);
+    
+    if (functionMatch) {
+      const functionName = functionMatch[1];
+      assert.ok(
+        bundleContent.includes(`function ${functionName}(`),
+        `Browser bundle should contain function ${functionName} from ${file}`
+      );
+      assert.ok(
+        bundleContent.includes(`${functionName}(turndownService);`),
+        `Browser bundle should call ${functionName} in addConfluenceRules`
+      );
+    }
+  });
+});
+
+test('browser bundle has required functions', () => {
+  const docsBundle = path.join(__dirname, '..', 'docs', 'turndownRules.js');
+  const bundleContent = fs.readFileSync(docsBundle, 'utf8');
+  
+  assert.ok(
+    bundleContent.includes('function getTurndownOptions()'),
+    'Browser bundle should contain getTurndownOptions function'
+  );
+  
+  assert.ok(
+    bundleContent.includes('function addConfluenceRules('),
+    'Browser bundle should contain addConfluenceRules function'
+  );
+  
+  assert.ok(
+    bundleContent.includes('// Auto-generated from lib/rules/'),
+    'Browser bundle should have auto-generated comment'
+  );
+});


### PR DESCRIPTION
- Created `build-browser.js` script to automatically generate browser-compatible bundle from `lib/rules/`
- Generated `docs/turndownRules.js` with all conversion rules (code blocks, inline code, tasks, lists, tables)
- Removed Node.js-specific `require()` and `module.exports` statements for browser compatibility
- Fixed script loading path in `docs/index.html` from `../lib/turndownRules.js` to `turndownRules.js`